### PR TITLE
(MODULES-6881) - Removing duplication in .sync.yml

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,22 +1,8 @@
 ---
-appveyor.yml:
-  environment:
-  PUPPET_GEM_VERSION: "~> 4.0"
-  matrix:
-    - RUBY_VERSION: 24-x64
-      CHECK: "syntax lint"
-    - RUBY_VERSION: 24-x64
-      CHECK: metadata_lint
-    - RUBY_VERSION: 24-x64
-      CHECK: rubocop
-
 .travis.yml:
-  bundle_args: --without system_tests
   docker_sets:
     - set: docker/centos-7
-      options:
     - set: docker/ubuntu-14.04
-      options:
   docker_defaults:
     bundler_args: ""
   secure: ""
@@ -47,10 +33,7 @@ Gemfile:
         from_env: BEAKER_HOSTGENERATOR_VERSION
       - gem: beaker-rspec
         from_env: BEAKER_RSPEC_VERSION
-    ':development':
-      - gem: puppet-blacksmith
-        version: '~> 3.4'
 
-Rakefile:
-  requires:
-    - puppet_blacksmith/rake_tasks
+.yardopts:
+  optional:
+    - --output-dir docs/


### PR DESCRIPTION
Due to updates in the pdk-templates, there are entries in the .sync.yml that are not required. Leaving them in just duplicates configurations. 