### PR TITLE
(maint) - Make redhat 7 version consistent in modules metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7.0"
+        "7"
       ]
     },
     {


### PR DESCRIPTION
Updating the version to 7. This will make the information in the file more more consistent with our other supported modules.