### PR TITLE
(DI-3301) Linux task should use eval

### DIFF
--- a/tasks/linux.sh
+++ b/tasks/linux.sh
@@ -52,9 +52,9 @@ fi
 
 # Run command, redirecting stderr if requested
 if [ "$interleave" == "true" ]; then
-    output_from_command=$(${command} 2>&1)
+    output_from_command=$(eval ${command} 2>&1)
 else
-    output_from_command=$(${command})
+    output_from_command=$(eval ${command})
 fi
 
 status_from_command=$?


### PR DESCRIPTION
The linux task executes commands on the shell, but not
all parameters will be escaped correctly.

This change uses the bash eval function to ensure the command
string is correctly evaluted when executing.

e.g. uses
-command='echo "Hello, World ${USER}" > /tmp/hello.txt'