### PR TITLE
(SEN-788) Make linux and windows private

### DIFF
--- a/tasks/init.json
+++ b/tasks/init.json
@@ -19,5 +19,11 @@
     {"name": "init.rb", "requirements": ["puppet-agent"]},
     {"name": "windows.ps1", "requirements": ["powershell"], "input_method": "powershell"},
     {"name": "linux.sh", "requirements": ["shell"], "input_method": "environment"}
-  ]
+  ],
+  "extensions": {
+    "discovery": {
+      "friendlyName": "Run a shell command",
+      "type": ["host"]
+    }
+  }
 }

--- a/tasks/linux.json
+++ b/tasks/linux.json
@@ -1,17 +1,11 @@
 {
   "description": "Execute an arbitrary shell command (without a puppet agent)",
+  "private": true,
   "input_method": "environment",
   "parameters": {
     "command": {
       "description": "The command to run, including all arguments.",
       "type": "String[1]"
-    }
-  },
-  "extensions": {
-    "discovery": {
-        "friendlyName": "Run a shell command on Linux",
-        "osFamily": "linux",
-        "type": ["host"]
     }
   }
 }

--- a/tasks/windows.json
+++ b/tasks/windows.json
@@ -1,17 +1,11 @@
 {
   "description": "Execute an arbitrary shell command (without a puppet agent)",
+  "private": true,
   "input_method": "powershell",
   "parameters": {
     "command": {
       "description": "The command to run, including all arguments.",
       "type": "String[1]"
-    }
-  },
-  "extensions": {
-    "discovery": {
-      "friendlyName": "Run a shell command on Windows",
-      "osFamily": "windows",
-      "type": ["host"]
     }
   }
 }


### PR DESCRIPTION
**Changes**
**1. Move extension metadata:**
windows.json and linux.json are private tasks and won't be surfaced. For this reason the discovery extension metadata should only be added into the init.json file

**2. Make linux.json and windows.json private**
The newly added implementation section will allow the correct implementation to be used for each host (windows.ps1 or linux.sh). With this change we don't need to surface the windows.json and linux.json files so they've been marked private