### PR TITLE
pdksync - (IAC-1720) - Add Support for Ubuntu 20.04

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -44,6 +44,7 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
+        "\"20.04\"",
         "16.04",
         "18.04"
       ]


### PR DESCRIPTION
(IAC-1720) - Add Support for Ubuntu 20.04
pdk version: `2.1.0` 
