### PR TITLE
pdksync - (IAC-1720) - Add Support for Ubuntu 20.04

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -45,7 +45,8 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "16.04",
-        "18.04"
+        "18.04",
+        "20.04"
       ]
     },
     {


### PR DESCRIPTION
(IAC-1720) - Add Support for Ubuntu 20.04
pdk version: `2.1.0` 
