### PR TITLE
(MAINT) Drop Support for Windows Server 2008 R2.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -20,8 +20,7 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7",
-        "8"
+        "7"
       ]
     },
     {
@@ -52,7 +51,6 @@
       "operatingsystem": "Windows",
       "operatingsystemrelease": [
         "10",
-        "2008 R2",
         "2012 R2",
         "2016",
         "2019",

--- a/metadata.json
+++ b/metadata.json
@@ -20,7 +20,8 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7"
+        "7",
+        "8"
       ]
     },
     {


### PR DESCRIPTION
(MAINT) Drop Support for Windows Server 2008 R2.
Prior to this commit the metadata.json file for this module listed OSs that are not supported by puppet agent as supported. This commit aims to refactor the metadata.json file to only list OSs that are supported by puppet agent.

This included the removal of Windows Server 2008 R2.

The list of supported OSs can be found here:
https://puppet.com/docs/pe/2021.7/supported_operating_systems.html