### PR TITLE
pdksync - (CAT-1301) Roll out puppet-lint plugin check_unsafe_interpolations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,27 +14,28 @@ def location_for(place_or_version, fake_version = nil)
 end
 
 group :development do
-  gem "json", '= 2.1.0',                           require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.3.0',                           require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.5.1',                           require: false if Gem::Requirement.create(['>= 3.0.0', '< 3.0.5']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.6.1',                           require: false if Gem::Requirement.create(['>= 3.1.0', '< 3.1.3']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.6.3',                           require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "voxpupuli-puppet-lint-plugins", '~> 4.0',   require: false
-  gem "facterdb", '~> 1.18',                       require: false
-  gem "metadata-json-lint", '>= 2.0.2', '< 4.0.0', require: false
-  gem "puppetlabs_spec_helper", '~> 5.0',          require: false
-  gem "rspec-puppet-facts", '~> 2.0',              require: false
-  gem "codecov", '~> 0.2',                         require: false
-  gem "dependency_checker", '~> 0.2',              require: false
-  gem "parallel_tests", '~> 3.4',                  require: false
-  gem "pry", '~> 0.10',                            require: false
-  gem "simplecov-console", '~> 0.5',               require: false
-  gem "puppet-debugger", '~> 1.0',                 require: false
-  gem "rubocop",  "~> 1.48.1",                     require: false
-  gem "rubocop-rspec", "~> 2.19",                  require: false
-  gem "rubocop-performance", "~> 1.16",            require: false
-  gem "rb-readline", '= 0.5.5',                    require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "github_changelog_generator", '= 1.15.2',    require: false
+  gem "json", '= 2.1.0',                                     require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.3.0',                                     require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.5.1',                                     require: false if Gem::Requirement.create(['>= 3.0.0', '< 3.0.5']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.6.1',                                     require: false if Gem::Requirement.create(['>= 3.1.0', '< 3.1.3']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.6.3',                                     require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "voxpupuli-puppet-lint-plugins", '~> 4.0',             require: false
+  gem "facterdb", '~> 1.18',                                 require: false
+  gem "metadata-json-lint", '>= 2.0.2', '< 4.0.0',           require: false
+  gem "puppetlabs_spec_helper", '~> 5.0',                    require: false
+  gem "rspec-puppet-facts", '~> 2.0',                        require: false
+  gem "codecov", '~> 0.2',                                   require: false
+  gem "dependency_checker", '~> 0.2',                        require: false
+  gem "parallel_tests", '~> 3.4',                            require: false
+  gem "pry", '~> 0.10',                                      require: false
+  gem "simplecov-console", '~> 0.5',                         require: false
+  gem "puppet-debugger", '~> 1.0',                           require: false
+  gem "rubocop",  "~> 1.48.1",                               require: false
+  gem "rubocop-rspec", "~> 2.19",                            require: false
+  gem "rubocop-performance", "~> 1.16",                      require: false
+  gem "rb-readline", '= 0.5.5',                              require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "github_changelog_generator", '= 1.15.2',              require: false
+  gem 'puppet-lint-check_unsafe_interpolations', '~> 0.0.4', require: false
 end
 group :system_tests do
   gem "puppet_litmus", '~> 1.0', require: false, platforms: [:ruby, :x64_mingw]


### PR DESCRIPTION
(CAT-1301) Roll out puppet-lint plugin check_unsafe_interpolations
pdk version: `3.0.0` 
