### PR TITLE
pdksync - (CAT-1366) - Fix issue url from old jira to github

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,6 +5,7 @@
   "summary": "Tasks that allows the execution of a command and parameters",
   "license": "Apache-2.0",
   "source": "https://github.com/puppetlabs/puppetlabs-exec",
+  "issues_url": "https://github.com/puppetlabs/puppetlabs-exec/issues",
   "dependencies": [
 
   ],


### PR DESCRIPTION
(CAT-1366) - Fix issue url from old jira to github
pdk version: `2.7.0` 
