### PR TITLE
Correctly handle non-default parameter booleans

### DIFF
--- a/tasks/init.rb
+++ b/tasks/init.rb
@@ -25,7 +25,7 @@ end
 
 def default_true(params, key)
   v = params[key]
-  return unless v.nil?
+  return v unless v.nil?
 
   true
 end


### PR DESCRIPTION
## Summary
Passing non-default booleans does not always work correctly.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)