### PR TITLE
Reinstate Ubuntu-2004 github actions runner image for nightly tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,3 +15,5 @@ jobs:
     needs: Spec
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
     secrets: "inherit"
+    with:
+      runs_on: "ubuntu-20.04"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,3 +14,5 @@ jobs:
     needs: Spec
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
     secrets: "inherit"
+    with:
+      runs_on: "ubuntu-20.04"


### PR DESCRIPTION
## Summary
Reinstate Ubuntu-2004 github actions runner image for nightly tests and CI

## Additional Context
This is done because Centos-7, OracleLinux-7 and Scientific-7 are not getting provisioned on the ubuntu-2204 github runner image resulting in nightly job failures: https://github.com/puppetlabs/puppetlabs-accounts/actions/runs/11395047245. This might be due to the EOL status of EL-7 based images.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)