### PR TITLE
(MODULES-11579) Add support for powershell CLI to exec::windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ For example, to view the free disk space of a host, run:
 This example is specifically for Windows using Powershell and returns a list of features installed on the server:
 `puppet task run exec command='powershell -command "Get-WindowsFeature  | Where Installed | Format-List -Property Name"' --nodes neptune`
 
+* For exec::windows task, CLI provider can also be passed using the 'provider' parameter. Supported CLIs are cmd and powershell, with default being cmd.
+`puppet task run exec provider=powershell command="Get-WindowsFeature  | Where Installed | Format-List -Property Name" --nodes neptune`
+
 You can also run tasks in the PE console. See PE task documentation for complete information.
 
 ## Reference

--- a/tasks/windows.json
+++ b/tasks/windows.json
@@ -6,6 +6,10 @@
     "command": {
       "description": "The command to run, including all arguments.",
       "type": "String[1]"
+    },
+    "provider": {
+      "description": "The CLI provider to run the command on. Supported providers are 'cmd' and 'powershell'. Default is 'cmd'.",
+      "type": "Optional[String]"
     }
   }
 }

--- a/tasks/windows.ps1
+++ b/tasks/windows.ps1
@@ -11,7 +11,11 @@ param(
 
     [Parameter(Mandatory = $false)]
     [bool]
-    $FailOnFail=$true
+    $FailOnFail=$true,
+
+    [Parameter(Mandatory = $false)]
+    [String]
+    $Provider="cmd"
 )
 
 function write_error($Message, $ExitCode){
@@ -34,7 +38,18 @@ if ($Interleave -eq $true){
     $Redirect = "2>&1"
 }
 
-$CommandOutput = cmd /c $Command $Redirect
+if ($Provider -eq "cmd") {
+  $CommandOutput = cmd /c $Command $Redirect
+} elseif ($Provider -eq "powershell") {
+  if ($Interleave -eq $true) {
+    $CommandOutput = powershell -Command $Command 2>&1
+  } else {
+    $CommandOutput = powershell -Command $Command
+  }
+} else {
+  write_error -Message "Unsupported provider: $Provider" -ExitCode 1
+}
+    
 if ($LASTEXITCODE -eq 0){
     echo $CommandOutput
 }


### PR DESCRIPTION
## Summary
This adds support for provider parameter which current support 'cmd' and 'powershell'(Default: cmd). When provider=powershell, the command provided to the exec task will be run on a powershell terminal.

## Additional Context

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)